### PR TITLE
Turning test jobs into reusable workflow

### DIFF
--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -41,7 +41,7 @@ jobs:
     needs: BuildOSML
     uses: ./.github/workflows/osml_reusable_test.yml
     with:
-      TEST_DESCRIPTION: "Run Small Tif using Centerpoint Model"
+      TEST_DESCRIPTION: "Run small.tif using Centerpoint Model"
       TEST_IMAGE: "small"
       TEST_MODEL: "centerpoint"
     secrets: inherit
@@ -49,7 +49,7 @@ jobs:
     needs: RunSmallTifCenterpointTest
     uses: ./.github/workflows/osml_reusable_test.yml
     with:
-      TEST_DESCRIPTION: "Run Meta Tif using Centerpoint Model"
+      TEST_DESCRIPTION: "Run meta.ntf using Centerpoint Model"
       TEST_IMAGE: "meta"
       TEST_MODEL: "centerpoint"
     secrets: inherit
@@ -57,7 +57,7 @@ jobs:
     needs: RunMetaNtfCenterpointTest
     uses: ./.github/workflows/osml_reusable_test.yml
     with:
-      TEST_DESCRIPTION: "Run Large Tif using Flood Model"
+      TEST_DESCRIPTION: "Run large.tif using Flood Model"
       TEST_IMAGE: "large"
       TEST_MODEL: "flood"
     secrets: inherit
@@ -65,7 +65,7 @@ jobs:
     needs: RunLargeTifFloodTest
     uses: ./.github/workflows/osml_reusable_test.yml
     with:
-      TEST_DESCRIPTION: "Run Tile Ntf using Aircraft Model"
+      TEST_DESCRIPTION: "Run tile.ntf using Aircraft Model"
       TEST_IMAGE: "tile_ntf"
       TEST_MODEL: "aircraft"
     secrets: inherit
@@ -73,7 +73,7 @@ jobs:
     needs: RunTileNtfAircraftTest
     uses: ./.github/workflows/osml_reusable_test.yml
     with:
-      TEST_DESCRIPTION: "Run Tile Tif using Aircraft Model"
+      TEST_DESCRIPTION: "Run tile.tif using Aircraft Model"
       TEST_IMAGE: "tile_tif"
       TEST_MODEL: "aircraft"
     secrets: inherit

--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - dev
       - main
-  push:
-    branches:
-      - dev
-      - main
 
 env:
   AWS_REGION: "us-west-2"
@@ -43,106 +39,41 @@ jobs:
           buildspec-override: .github/codebuild/build.yml
   RunSmallTifCenterpointTest:
     needs: BuildOSML
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-      - name: Run Small Tif using Centerpoint Model
-        uses: aws-actions/aws-codebuild-run-build@v1
-        env:
-            TEST_IMAGE: "small"
-            TEST_MODEL: "centerpoint"
-        with:
-          env-vars-for-codebuild: |
-            TEST_IMAGE,
-            TEST_MODEL
-          project-name: CodeBuild-TestGithubOSML
-          buildspec-override: .github/codebuild/test.yml
+    uses: ./.github/workflows/osml_reusable_test.yml
+    with:
+      TEST_DESCRIPTION: "Run Small Tif using Centerpoint Model"
+      TEST_IMAGE: "small"
+      TEST_MODEL: "centerpoint"
+    secrets: inherit
   RunMetaNtfCenterpointTest:
     needs: RunSmallTifCenterpointTest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-      - name: Run Meta Ntf using Centerpoint Model
-        uses: aws-actions/aws-codebuild-run-build@v1
-        env:
-            TEST_IMAGE: "meta"
-            TEST_MODEL: "centerpoint"
-        with:
-          env-vars-for-codebuild: |
-            TEST_IMAGE,
-            TEST_MODEL
-          project-name: CodeBuild-TestGithubOSML
-          buildspec-override: .github/codebuild/test.yml
+    uses: ./.github/workflows/osml_reusable_test.yml
+    with:
+      TEST_DESCRIPTION: "Run Meta Tif using Centerpoint Model"
+      TEST_IMAGE: "meta"
+      TEST_MODEL: "centerpoint"
+    secrets: inherit
   RunLargeTifFloodTest:
     needs: RunMetaNtfCenterpointTest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-      - name: Run Large Tif using Flood Model
-        uses: aws-actions/aws-codebuild-run-build@v1
-        env:
-            TEST_IMAGE: "large"
-            TEST_MODEL: "flood"
-        with:
-          env-vars-for-codebuild: |
-            TEST_IMAGE,
-            TEST_MODEL
-          project-name: CodeBuild-TestGithubOSML
-          buildspec-override: .github/codebuild/test.yml
+    uses: ./.github/workflows/osml_reusable_test.yml
+    with:
+      TEST_DESCRIPTION: "Run Large Tif using Flood Model"
+      TEST_IMAGE: "large"
+      TEST_MODEL: "flood"
+    secrets: inherit
   RunTileNtfAircraftTest:
     needs: RunLargeTifFloodTest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-      - name: Run Tile Ntf using Aircraft Model
-        uses: aws-actions/aws-codebuild-run-build@v1
-        env:
-            TEST_IMAGE: "tile_ntf"
-            TEST_MODEL: "aircraft"
-        with:
-          env-vars-for-codebuild: |
-            TEST_IMAGE,
-            TEST_MODEL
-          project-name: CodeBuild-TestGithubOSML
-          buildspec-override: .github/codebuild/test.yml
+    uses: ./.github/workflows/osml_reusable_test.yml
+    with:
+      TEST_DESCRIPTION: "Run Tile Ntf using Aircraft Model"
+      TEST_IMAGE: "tile_ntf"
+      TEST_MODEL: "aircraft"
+    secrets: inherit
   RunTileTifAircraftTest:
     needs: RunTileNtfAircraftTest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-      - name: Run Tile Tif using Aircraft Model
-        uses: aws-actions/aws-codebuild-run-build@v1
-        env:
-            TEST_IMAGE: "tile_tif"
-            TEST_MODEL: "aircraft"
-        with:
-          env-vars-for-codebuild: |
-            TEST_IMAGE,
-            TEST_MODEL
-          project-name: CodeBuild-TestGithubOSML
-          buildspec-override: .github/codebuild/test.yml
+    uses: ./.github/workflows/osml_reusable_test.yml
+    with:
+      TEST_DESCRIPTION: "Run Tile Tif using Aircraft Model"
+      TEST_IMAGE: "tile_tif"
+      TEST_MODEL: "aircraft"
+    secrets: inherit

--- a/.github/workflows/osml_reusable_test.yml
+++ b/.github/workflows/osml_reusable_test.yml
@@ -1,0 +1,36 @@
+name: 'OSML Reusable Test Workflow'
+
+on:
+  workflow_call:
+    inputs:
+      TEST_DESCRIPTION:
+        required: true
+        type: string
+      TEST_IMAGE:
+        required: true
+        type: string
+      TEST_MODEL:
+        required: true
+        type: string
+
+jobs:
+  RunOSMLTest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+      - name: ${{ inputs.TEST_DESCRIPTION }}
+        uses: aws-actions/aws-codebuild-run-build@v1
+        env:
+            TEST_IMAGE: ${{ inputs.TEST_IMAGE }}
+            TEST_MODEL: ${{ inputs.TEST_MODEL }}
+        with:
+          env-vars-for-codebuild: |
+            TEST_IMAGE,
+            TEST_MODEL
+          project-name: CodeBuild-TestGithubOSML
+          buildspec-override: .github/codebuild/test.yml


### PR DESCRIPTION
**Issue #, if available:** n/a

**Description of changes:**
- Removed `push` actions
- Converting all test jobs into using reusable workflow, makes it cleaner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
