### PR TITLE
Official npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # guidance-for-overhead-imagery-inference-on-aws
 
 ### Table of Contents
-  * [Installation](#installation)
-  * [Linting/Formatting](#lintingformatting)
-  * [Deployment](#deployment)
-  * [Usage](#usage)
-    * [OSML Model Runner](#osml-model-runner)
-    * [OSML Model Runner Test](#osml-model-runner-test)
-    * [OSML Cesium Globe](#osml-cesium-globe)
-    * [OSML Models](#osml-models)
-  * [Useful Commands](#useful-commands)
-  * [Troubleshooting](#troubleshooting)
-      * [Permission Denied for submodules](#permission-denied-for-submodules)
-      * [Exit code: 137; Deployment failed: Error: Failed to build asset](#exit-code-137-deployment-failed-error-failed-to-build-asset-)
-  * [Support & Feedback](#support--feedback)
-    * [Supporting OSML Repositories](#supporting-osml-repositories)
-  * [Security](#security)
-  * [License](#license)
+
+* [Installation](#installation)
+* [Linting/Formatting](#lintingformatting)
+* [Deployment](#deployment)
+  * [Deploying Local osml-cdk-constructs](#deploying-local-osml-cdk-constructs)
+* [Usage](#usage)
+  * [OSML Model Runner](#osml-model-runner)
+  * [OSML Model Runner Test](#osml-model-runner-test)
+  * [OSML Cesium Globe](#osml-cesium-globe)
+  * [OSML Models](#osml-models)
+* [Useful Commands](#useful-commands)
+* [Troubleshooting](#troubleshooting)
+  * [Permission Denied for submodules](#permission-denied-for-submodules)
+  * [Exit code: 137; Deployment failed: Error: Failed to build asset](#exit-code-137-deployment-failed-error-failed-to-build-asset-)
+* [Support & Feedback](#support--feedback)
+  * [Supporting OSML Repositories](#supporting-osml-repositories)
+* [Security](#security)
+* [License](#license)
 
 ## Installation
 
@@ -44,6 +46,7 @@ brew install git-lfs
 Otherwise, consult the official git-lfs [installation documentation](https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&utm_medium=installation_link&utm_campaign=gitlfs#installing).
 
 Clone the repository, pull lfs files, and sync the submodules:
+
 ```bash
 git clone https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws.git
 cd guidance-for-overhead-imagery-inference-on-aws
@@ -52,6 +55,7 @@ git submodule update --init --recursive
 ```
 
 If you want to pull subsequent changes to submodule packages, run:
+
 ```bash
 git submodule update --recursive --remote
 ```
@@ -60,21 +64,21 @@ git submodule update --recursive --remote
 
 This package uses a number of tools to enforce formatting, linting, and general best practices:
 
-- [black](https://github.com/psf/black) for formatting python files with community standards
-- [isort](https://github.com/PyCQA/isort) for formatting with a max line length of 100
-- [mypy](https://github.com/pre-commit/mirrors-mypy) to enforce static type checking
-- [flake8](https://github.com/PyCQA/flake8) to check pep8 compliance and logical errors in code
-- [autopep](https://github.com/pre-commit/mirrors-autopep8) to check pep8 compliance and logical errors in code
-- [eslint](https://github.com/pre-commit/mirrors-eslint) to check pep8 compliance and logical errors in code
-- [prettier](https://github.com/pre-commit/mirrors-prettier) to check pep8 compliance and logical errors in code
-- [pre-commit](https://github.com/pre-commit/pre-commit-hooks) to install and control linters in githooks
-
+* [black](https://github.com/psf/black) for formatting python files with community standards
+* [isort](https://github.com/PyCQA/isort) for formatting with a max line length of 100
+* [mypy](https://github.com/pre-commit/mirrors-mypy) to enforce static type checking
+* [flake8](https://github.com/PyCQA/flake8) to check pep8 compliance and logical errors in code
+* [autopep](https://github.com/pre-commit/mirrors-autopep8) to check pep8 compliance and logical errors in code
+* [eslint](https://github.com/pre-commit/mirrors-eslint) to check pep8 compliance and logical errors in code
+* [prettier](https://github.com/pre-commit/mirrors-prettier) to check pep8 compliance and logical errors in code
+* [pre-commit](https://github.com/pre-commit/pre-commit-hooks) to install and control linters in githooks
 
 ## Deployment
 
 1. Create an AWS account
 2. Create `target_account.json` under `guidance-for-overhead-imagery-inference-on-aws/lib/accounts/`
 3. Copy the below template into `target_account.json` and update your account number, alias, and region:
+
    ```text
    {
        "id": <target account id for deployment>,
@@ -86,18 +90,23 @@ This package uses a number of tools to enforce formatting, linting, and general 
        "enableTesting": <false || true enable testing infrastructure>
    }
    ```
+
 4. Export your dev account number and deployment username:
+
    ```
    export ACCOUNT_NUMBER=<target account number>
    export AWS_DEFAULT_REGION=<target region for deployment>,
    export NAME=<unique name for stacks>
    ```
+
 5. Pull your latest credentials into `~/.aws/credentials`
 
 6. Go into `guidance-for-overhead-imagery-inference-on-aws` directory and execute the following commands to install npm packages:
+
    ```
    npm i
    ```
+
 7. If this is your first time deploying stacks to your account, please see below (Step 9). If not, skip this step:
 
    ```
@@ -113,20 +122,50 @@ This package uses a number of tools to enforce formatting, linting, and general 
    ```
 
 9. Then deploy the stacks to your commercial account:
+
    ```
    npm run deploy
    ```
+
 10. If you want to validate the deployment with integration tests:
+
    ```
    npm run setup
    npm run integ
    ```
 
 11. When you are done you can clean up the deployment:
+
    ```
    npm run destroy
    ```
+
+### Deploying Local osml-cdk-constructs
+
+By default this package uses the osml-cdk-constructs defined in the [official NPM repository](https://www.npmjs.com/package/osml-cdk-constructs?activeTab=readme). If you wish to make changes to the `lib/osml-cdk-constructs` submodule in this project and what to use those changes when deploying, then follow these steps to switch out the remote NPM package for the local package.
+
+1. In `package.json`, locate `osml-cdk-constructs` under devDependencies. By default it points to the latest NPM package version, but swap out the version number with `"file:lib/osml-cdk-constructs"`. This will tell package.json to use the local package instead. The dependency will now look like this:
+
+```
+"osml-cdk-constructs": "file:lib/osml-cdk-constructs"
+```
+
+2. Update the imports in `lib/osml-stacks/model_runner/dataplane.ts`. By default all CDK constructs are pulled from the `osml-cdk-constructs` npm package, but now they must be imported by file path. Delete the existing `osml-cdk-constructs` import and replace it with the following: 
+
+```
+import { MRDataplane } from "osml-cdk-constructs/lib/model_runner/mr_dataplane"
+import { OSMLAccount } from "osml-cdk-constructs/lib/osml/osml_account"
+import { MRTesting } from "osml-cdk-constructs/lib/model_runner/mr_testing"
+import { MRMonitoring } from "osml-cdk-constructs/lib/model_runner/mr_monitoring"
+```
+
+3. Execute `npm i` to make sure everything is installed and building correctly.
+
+4. You can now follow the [normal deployment](#deployment) steps to deploy your local changes in `osml-cdk-constructs`.
+
+
 ## Usage
+
 To start a job, place an `ImageRequest` on the `ImageRequestQueue` by going into your AWS Console > Simple Queue System > `ImageRequestQueue` > Send and receive messages > and enter the provided sample for an `ImageRequest`:
 
 **Sample ImageRequest:**
@@ -167,6 +206,7 @@ Below are additional details about each key-value pair in the image request:
 Here is an example of a complete image request:
 
 **Example ImageRequest:**
+
 ```json
 {
    "jobId": "testid1", 
@@ -188,6 +228,7 @@ Here is an example of a complete image request:
 Here is some useful information about each of the OSML components:
 
 ### OSML Model Runner
+
 This package contains an application used to orchestrate the execution of ML models on large satellite images. The
 application monitors an input queue for processing requests, decomposes the image into a set of smaller regions and
 tiles, invokes an ML model endpoint with each tile, and finally aggregates all the results into a single output. The
@@ -197,28 +238,31 @@ across instances to process images as quickly as possible.
 For more info see [osml-model-runner](https://github.com/aws-solutions-library-samples/osml-model-runner)
 
 ### OSML Model Runner Test
+
 This package contains the integration tests for OSML application
 
 For more info see [osml-model-runner-test](https://github.com/aws-solutions-library-samples/osml-model-runner-test)
 
 ### OSML Cesium Globe
+
 Build a way to visualize and display results from our image processing workflow.
 
 For more info see [osml-cesium-globe](https://github.com/aws-solutions-library-samples/osml-cesium-globe)
 
 ### OSML Models
+
 This package contains sample models that can be used to test OversightML installations without incurring high compute costs typically associated with complex Computer Vision models. These models implement an interface compatible with SageMaker and are suitable for deployment as endpoints with CPU instances.
 
 For more info see [osml-models](https://github.com/aws-solutions-library-samples/osml-models)
 
 ## Useful Commands
 
-- `npm run build` compile typescript to js
-- `npm run watch` watch for changes and compile
-- `npm run deploy` deploy all stacks to your account
-- `npm run integ` run integration tests against deployment
-- `npm run clean` clean up build files and node modules
-- `npm run synth` synthesizes CloudFormation templates for deployments
+* `npm run build` compile typescript to js
+* `npm run watch` watch for changes and compile
+* `npm run deploy` deploy all stacks to your account
+* `npm run integ` run integration tests against deployment
+* `npm run clean` clean up build files and node modules
+* `npm run synth` synthesizes CloudFormation templates for deployments
 
 ## Troubleshooting
 
@@ -231,6 +275,7 @@ If you are facing a permission denied issue where you are trying to `git submodu
 #### Exit code: 137; Deployment failed: Error: Failed to build asset 
 
 If you are facing this error while trying to execute `npm run deploy`, it indiciates that Docker is running out of memory and requires additional ram to support it. You can increase memory by completing the following steps:
+
 1. Open Docker UI
 2. Click `Settings` gear icon on top-right
 3. Click `Resources` on the left sidebar menu
@@ -244,12 +289,13 @@ To post feedback, submit feature ideas, or report bugs, please use the [Issues](
 If you are interested in contributing to OversightML Model Runner, see the [CONTRIBUTING](CONTRIBUTING.md) guide.
 
 ### Supporting OSML Repositories
-- [osml-cdk-constructs](https://github.com/aws-solutions-library-samples/osml-cdk-constructs)
-- [osml-cesium-globe](https://github.com/aws-solutions-library-samples/osml-cesium-globe)
-- [osml-imagery-toolkit](https://github.com/aws-solutions-library-samples/osml-imagery-toolkit)
-- [osml-model-runner](https://github.com/aws-solutions-library-samples/osml-model-runner)
-- [osml-model-runner-test](https://github.com/aws-solutions-library-samples/osml-model-runner-test)
-- [osml-models](https://github.com/aws-solutions-library-samples/osml-models)
+
+* [osml-cdk-constructs](https://github.com/aws-solutions-library-samples/osml-cdk-constructs)
+* [osml-cesium-globe](https://github.com/aws-solutions-library-samples/osml-cesium-globe)
+* [osml-imagery-toolkit](https://github.com/aws-solutions-library-samples/osml-imagery-toolkit)
+* [osml-model-runner](https://github.com/aws-solutions-library-samples/osml-model-runner)
+* [osml-model-runner-test](https://github.com/aws-solutions-library-samples/osml-model-runner-test)
+* [osml-models](https://github.com/aws-solutions-library-samples/osml-models)
 
 ## Security
 
@@ -258,6 +304,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 MIT No Attribution Licensed. See [LICENSE](LICENSE).
-
-
-

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This package uses a number of tools to enforce formatting, linting, and general 
 
 ### Deploying Local osml-cdk-constructs
 
-By default this package uses the osml-cdk-constructs defined in the [official NPM repository](https://www.npmjs.com/package/osml-cdk-constructs?activeTab=readme). If you wish to make changes to the `lib/osml-cdk-constructs` submodule in this project and what to use those changes when deploying, then follow these steps to switch out the remote NPM package for the local package.
+By default this package uses the osml-cdk-constructs defined in the [official NPM repository](https://www.npmjs.com/package/osml-cdk-constructs?activeTab=readme). If you wish to make changes to the `lib/osml-cdk-constructs` submodule in this project and want to use those changes when deploying, then follow these steps to switch out the remote NPM package for the local package.
 
 1. In `package.json`, locate `osml-cdk-constructs` under devDependencies. By default it points to the latest NPM package version, but swap out the version number with `"file:lib/osml-cdk-constructs"`. This will tell package.json to use the local package instead. The dependency will now look like this:
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This package uses a number of tools to enforce formatting, linting, and general 
 
 By default this package uses the osml-cdk-constructs defined in the [official NPM repository](https://www.npmjs.com/package/osml-cdk-constructs?activeTab=readme). If you wish to make changes to the `lib/osml-cdk-constructs` submodule in this project and want to use those changes when deploying, then follow these steps to switch out the remote NPM package for the local package.
 
-1. In `package.json`, locate `osml-cdk-constructs` under devDependencies. By default it points to the latest NPM package version, but swap out the version number with `"file:lib/osml-cdk-constructs"`. This will tell package.json to use the local package instead. The dependency will now look like this:
+1. In `package.json`, locate `osml-cdk-constructs` under `devDependencies`. By default it points to the latest NPM package version, but swap out the version number with `"file:lib/osml-cdk-constructs"`. This will tell package.json to use the local package instead. The dependency will now look like this:
 
 ```
 "osml-cdk-constructs": "file:lib/osml-cdk-constructs"

--- a/lib/osml-stacks/model_runner/dataplane.ts
+++ b/lib/osml-stacks/model_runner/dataplane.ts
@@ -3,10 +3,7 @@
  */
 
 import { App, Environment, Stack, StackProps } from "aws-cdk-lib";
-import { MRDataplane } from "osml-cdk-constructs/lib/model_runner/mr_dataplane"
-import { OSMLAccount } from "osml-cdk-constructs/lib/osml/osml_account"
-import { MRTesting } from "osml-cdk-constructs/lib/model_runner/mr_testing"
-import { MRMonitoring } from "osml-cdk-constructs/lib/model_runner/mr_monitoring"
+import { MRDataplane, OSMLAccount, MRTesting, MRMonitoring } from "osml-cdk-constructs"
 
 export interface MRDataplaneStackProps extends StackProps {
   // target deployment environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,14 @@
         "osml": "bin/app.ts"
       },
       "devDependencies": {
+        "@cdklabs/cdk-enterprise-iac": "^0.0.303",
         "@types/jest": "^29.5.2",
         "@types/node": "*",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.48.2",
         "aws-cdk": "^2.85.0",
         "aws-cdk-lib": "^2.85.0",
+        "cdk-ecr-deployment": "^2.5.30",
         "cdk-nag": "^2.27.48",
         "constructs": "^10.2.57",
         "eslint": "^8.32.0",
@@ -33,7 +35,7 @@
         "eslint-plugin-simple-import-sort": "^8.0.0",
         "jest": "^29.3.1",
         "lint-staged": "^13.1.0",
-        "osml-cdk-constructs": "file:lib/osml-cdk-constructs",
+        "osml-cdk-constructs": "^1.0.9",
         "prettier": "^2.8.3",
         "ts-jest": "^29.0.5",
         "typescript": "^5.1.3"
@@ -41,7 +43,7 @@
     },
     "lib/osml-cdk-constructs": {
       "version": "1.0.5",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
         "@cdklabs/cdk-enterprise-iac": "^0.0.303",
@@ -6688,8 +6690,14 @@
       }
     },
     "node_modules/osml-cdk-constructs": {
-      "resolved": "lib/osml-cdk-constructs",
-      "link": true
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/osml-cdk-constructs/-/osml-cdk-constructs-1.0.9.tgz",
+      "integrity": "sha512-3sums/Hdg8oIS5FgyWcmqjt0LJMaQDBkVWPWnL5SOv3zquOj+8T+ePXCwWJuQCYS+0hEq1BC0cUIopq9ywj5Jg==",
+      "dev": true,
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.63.2",
+        "constructs": "^10.1.252"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "ts-node": "^10.9.1"
   },
   "devDependencies": {
+    "@cdklabs/cdk-enterprise-iac": "^0.0.303",
     "@types/jest": "^29.5.2",
     "@types/node": "*",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.48.2",
     "aws-cdk": "^2.85.0",
     "aws-cdk-lib": "^2.85.0",
+    "cdk-ecr-deployment": "^2.5.30",
     "cdk-nag": "^2.27.48",
     "constructs": "^10.2.57",
     "eslint": "^8.32.0",
@@ -41,10 +43,10 @@
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "jest": "^29.3.1",
     "lint-staged": "^13.1.0",
+    "osml-cdk-constructs": "^1.0.9",
     "prettier": "^2.8.3",
     "ts-jest": "^29.0.5",
-    "typescript": "^5.1.3",
-    "osml-cdk-constructs": "file:lib/osml-cdk-constructs"
+    "typescript": "^5.1.3"
   },
   "browser": {
     "child_process": false


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes

Use the official [npm package](https://www.npmjs.com/package/osml-cdk-constructs?activeTab=readme) instead of the local osml-cdk-constructs by default. 

Also updated the README with instructions on how to switch back to using the local osml-cdk-constructs package incase the user wants to deploy their own changes. 


### Testing

`npm i` succeeded. 


Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
