### PR TITLE
Add destroy github actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,8 @@
 name: 🐛 Bug Report
 description: Create a report to help us improve OSML
 title: "[Bug] "
-labels: "Type: bug"
+labels: "bug"
+projects: "aws-solutions-library-samples/5"
 
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,8 @@
 name: 💡 Feature Request
 description: Suggest an feature for OSML
 title: "[Feature Request] "
-labels: "Type: enhancement"
+labels: "enhancement"
+projects: "aws-solutions-library-samples/5"
 
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/support_question.yml
+++ b/.github/ISSUE_TEMPLATE/support_question.yml
@@ -1,7 +1,8 @@
 name: ❓ Question
 description: General question for OSML
 title: "[Question] "
-labels: "Type: question"
+labels: "question"
+projects: "aws-solutions-library-samples/5"
 
 body:
   - type: textarea

--- a/.github/codebuild/destroy.yml
+++ b/.github/codebuild/destroy.yml
@@ -1,0 +1,19 @@
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - sed -i "s/git@github.com:/https:\/\/github.com\//" .gitmodules
+      - cp lib/accounts/target_account_template.json lib/accounts/target_account.json
+      - sed -i "s/1234567890123/$AWS_ACCOUNT/" lib/accounts/target_account.json
+      - sed -i "s/fake-alias/$NAME/" lib/accounts/target_account.json
+      - sed -i "s/us-west-1/$AWS_DEFAULT_REGION/" lib/accounts/target_account.json
+      - cat lib/accounts/target_account.json
+      - git submodule update --init --recursive
+      - npm i
+      - npm install -g aws-cdk
+  build:
+    commands:
+      - npm run destroy
+  post_build:
+    commands:
+      - echo Destroy completed on `date`

--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -77,3 +77,19 @@ jobs:
       TEST_IMAGE: "tile_tif"
       TEST_MODEL: "aircraft"
     secrets: inherit
+  DestroyOSML:
+    if: ${{ always() }}
+    needs: [ BuildOSML, RunSmallTifCenterpointTest, RunMetaNtfCenterpointTest, RunLargeTifFloodTest, RunTileNtfAircraftTest, RunTileTifAircraftTest ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::${{ secrets[format('OSML_{0}', github.base_ref)] }}:role/GithubAction-AssumeRoleWithAction
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+      - name: Destroy OSML stack(s)
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: CodeBuild-BuildGithubOSML
+          buildspec-override: .github/codebuild/destroy.yml


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Add a step at the end to clean up the OSML stacks
- Adjust the Issue Template -- so whenever the issues is created, it will be put into a Project board
- Fix the Issue labels, it wasn't assigning it correctly

### Testing
- Ran in my personal github account to ensure it can destroy the OSML stacks regardless if the build/test succeeded or failed

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
