### PR TITLE
fix: Update integration test to use python script

### DIFF
--- a/.github/codebuild/build.yml
+++ b/.github/codebuild/build.yml
@@ -10,6 +10,7 @@ phases:
       - sed -i "s/1234567890123/$AWS_ACCOUNT/" lib/accounts/target_account.json
       - sed -i "s/fake-alias/$NAME/" lib/accounts/target_account.json
       - sed -i "s/us-west-1/$AWS_DEFAULT_REGION/" lib/accounts/target_account.json
+      - if [[ "${BASE_REF}" -eq "dev" ]]; then sed -i '$s/}/,\n"isDev":true}/' lib/accounts/target_account.json; fi
       - cat lib/accounts/target_account.json
       - yum install -y git-lfs
       - git-lfs pull

--- a/.github/codebuild/test.yml
+++ b/.github/codebuild/test.yml
@@ -7,4 +7,4 @@ phases:
       - python3 -m pip install lib/osml-model-runner-test/
   build:
     commands:
-      - ./lib/osml-model-runner-test/bin/run_test.sh ${TEST_IMAGE} ${TEST_MODEL} NITF JPEG ${AWS_DEFAULT_REGION} ${AWS_ACCOUNT}
+      - python3 ./lib/osml-model-runner-test/bin/process_image.py --image ${TEST_IMAGE} --model ${TEST_MODEL}

--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           project-name: CodeBuild-BuildGithubOSML
           buildspec-override: .github/codebuild/build.yml
+          env-vars-for-codebuild: |
+            BASE_REF
+        env:
+          BASE_REF: ${{ github.base_ref }}
   RunSmallTifCenterpointTest:
     needs: BuildOSML
     uses: ./.github/workflows/osml_reusable_test.yml


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Update integration tests to use python script instead of bash script
- Update build.yml in CodeBuild to set determine if the PR is against to dev branch is to set the `isDev` to `true`

### Testing
- Tested this workflow against my personal dev account and it succeeded. 

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
