### PR TITLE
fix: Use local CDK package if testing on dev branch

### DIFF
--- a/.github/codebuild/build.yml
+++ b/.github/codebuild/build.yml
@@ -5,8 +5,10 @@ phases:
       nodejs: 16
   pre_build:
     commands:
+      - cp package.json package_tmp.json
       - sed -i "s/git@github.com:/https:\/\/github.com\//" .gitmodules
       - if [[ "${BASE_REF}" -eq "dev" ]]; then jq '(.buildModelContainer, .buildAppContainer) = true' lib/accounts/target_account_template.json > lib/accounts/target_account.json; fi
+      - if [[ "${BASE_REF}" -eq "dev" ]]; then jq '(.devDependencies."osml-cdk-constructs") = "file:lib/osml-cdk-constructs"' package_tmp.json > package.json; fi
       - sed -i "s/1234567890123/$AWS_ACCOUNT/" lib/accounts/target_account.json
       - sed -i "s/fake-alias/$NAME/" lib/accounts/target_account.json
       - sed -i "s/us-west-1/$AWS_DEFAULT_REGION/" lib/accounts/target_account.json

--- a/.github/codebuild/build.yml
+++ b/.github/codebuild/build.yml
@@ -16,6 +16,7 @@ phases:
       - yum install -y git-lfs
       - git-lfs pull
       - git submodule update --init --recursive
+      - npm install lib/osml-cdk-constructs
       - npm i
       - npm install -g aws-cdk
   build:

--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
     - uses: ahmadnassri/action-workflow-queue@v1
       with:
-        delay: 60000
-        timeout: 1800000
+        delay: 600000
+        timeout: 3600000
   BuildOSML:
     needs: CheckPendingWorkflow
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- When we push out the changes for the CDK constructs, we didn't have any mechanism to test that, instead we use the latest version from npmjs
- Increased the Queue delay/timeout since each deployment takes about 1.5 hrs. 

### Testing
- Check the Github Actions to see if it succeeded or failed

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
