### PR TITLE
fix: Only cut PR against dev branch for submodules

### DIFF
--- a/.github/workflows/osml_update_submodules.yml
+++ b/.github/workflows/osml_update_submodules.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   update_submodules:
+    if: ${{ github.ref_name == ‘refs/heads/dev’ }}
     name: Update Submodules
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/osml_update_submodules.yml
+++ b/.github/workflows/osml_update_submodules.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   update_submodules:
-    if: ${{ github.ref_name == ‘refs/heads/dev’ }}
+    if: ${{ github.ref == ‘refs/heads/dev’ }}
     name: Update Submodules
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- We would only want the github workflow to auto-cut PR against dev branch only if there's any submodule changes. 

### Testing
- n/a


Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
