### PR TITLE
fix: Incorrect status for failed pytest 

### DIFF
--- a/.github/workflows/osml_build_test.yml
+++ b/.github/workflows/osml_build_test.yml
@@ -115,7 +115,7 @@ jobs:
       TEST_MODEL: "centerpoint"
     secrets: inherit
   DestroyOSML:
-    if: ${{ always() }}
+    if: ${{ false }}
     needs: [ BuildOSML, RunSmallTifCenterpointTest, RunMetaNtfCenterpointTest, RunLargeTifFloodTest, RunTileNtfAircraftTest, RunTileTifAircraftTest, RunSICDCapellaChipNtfTest, RunSICDUmbraChipNtfTest, RunSICDInterferometricHhNtfTest, RunWBIDTest ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- I have noticed that this [integration test](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/actions/runs/7947032993/job/21695664127) succeeded but it should have failed this workflow.

### Testing
- Check Github Actions

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
