### PR TITLE
test: implement ROI testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         types: [file, python]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: ["--ignore=E203,W503,W605", "--max-line-length=125"]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "watch": "tsc -w",
     "prepare": "npm run-script build",
     "integ:aircraft": "python3 lib/osml-model-runner-test/bin/process_image.py --image tile_tif --model aircraft",
+    "integ:aircraft-roi": "python3 lib/osml-model-runner-test/bin/process_image.py --image large --model aircraft --region-of-interest 'POLYGON ((-87.89041 42.94081, -87.89041 42.94436, -87.88584 42.94436, -87.88584 42.94081, -87.89041 42.94081))'",
     "integ:centerpoint": "python3 lib/osml-model-runner-test/bin/process_image.py --image small --model centerpoint",
     "integ:flood": "python3 lib/osml-model-runner-test/bin/process_image.py --image large --model flood",
     "integ:meta": "python3 lib/osml-model-runner-test/bin/process_image.py --image meta --model centerpoint",


### PR DESCRIPTION
### Notes
* Add `integ:aircraft-roi` test with known `--region-of-interest` parameter to test Region Of Interest functionality
* Fix pre-commit to use newer version of flake8 

### Testing
* Tested ROI functionality, confirmed fewer detections found compared to without ROI.

Before you submit a pull request, please make sure you have to following:

- [x] Your code contains tests that cover all new code and changes
- [x] All new and existing tests passed
- [x] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
