### PR TITLE
Failure Model Integ Testing with Checkered Color Tile Image

### DIFF
--- a/assets/images/failure_model_checker_tile.tif
+++ b/assets/images/failure_model_checker_tile.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e43c16ebfdb895b969c3ac4aa66c3ca06d8616be961a5e163ed6a34bbb547de
+size 12595454

--- a/scripts/model_runner_integ.sh
+++ b/scripts/model_runner_integ.sh
@@ -40,6 +40,8 @@ run_test() {
     local model=$3
     local region=$4
     local timeout_minutes=${5:-$DEFAULT_TIMEOUT_MINUTES}
+    local tileSize="${5:-512}"
+    local tileOverlap="${6:-128}"
 
     echo "=========================================="
     echo "Running: $description"
@@ -47,12 +49,14 @@ run_test() {
     echo "Model: $model"
     echo "Region: $region"
     echo "Timeout: ${timeout_minutes} minutes"
+    echo "Tile Size: ${tileSize}"
+    echo "Tile Overlap: ${tileOverlap}"
     echo "=========================================="
 
     # Set timeout environment variable for the Python script
     export TEST_TIMEOUT_MINUTES=$timeout_minutes
 
-    if python lib/osml-model-runner-test/bin/process_image.py --image "$image" --model "$model" --region "$region"; then
+    if python lib/osml-model-runner-test/bin/process_image.py --image "$image" --model "$model" --region "$region" --tile_size "$tileSize" --tile_overlap "$tileOverlap"; then
         echo "=========================================="
         echo "✓ $description: SUCCESS"
         echo "=========================================="
@@ -98,6 +102,8 @@ run_test "Run sicd-umbra-chip.ntf against centerpoint model" "sicd_umbra_chip_nt
 run_test "Run sicd-interferometric-hh.nitf against centerpoint model" "sicd_interferometric_hh_ntf" "centerpoint" $AWS_REGION
 run_test "Run wbid.nitf against centerpoint model" "wbid" "centerpoint" $AWS_REGION
 run_test "Run small.tif against multi-container endpoint" "small" "multi-container" $AWS_REGION
+
+run_test "Run failure_model_checker_tile.tif against failure model" "failure_model_checker_tile" "failure" $AWS_DEFAULT_REGION "512" "0"
 
 print_test_passed
 


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- This completes the failure model integration testing work. This feature will add the image and the updated integration test script with failure model and tile parameters. Git LFS updated with second commit to stage the image file. 
- This is dependent upon the other failure model PRs to be merged in and released:
   - [PR osml-model-runner-test](https://github.com/awslabs/osml-model-runner-test/pull/64)
   - [PR osml-models](https://github.com/awslabs/osml-models/pull/58)
   - [PR osml-cdk-constructs](https://github.com/awslabs/osml-cdk-constructs/pull/186)

### Testing
- Deployed and ran integration test script, successful ouput

Before you submit a pull request, please make sure you have to following:

- [ ] Your code contains tests that cover all new code and changes
- [ ] All new and existing tests passed
- [ ] I have read the [Contributing Guidelines](https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CONTRIBUTING.md) and agree to follow the [Code of Conduct](
https://github.com/aws-solutions-library-samples/guidance-for-overhead-imagery-inference-on-aws/blob/main/CODE_OF_CONDUCT.md))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
